### PR TITLE
Add halo–Sigma cross term to the Gaussian ΔΣ covariance (linear bias)

### DIFF
--- a/clens/lensing/angular_power_spectra.py
+++ b/clens/lensing/angular_power_spectra.py
@@ -206,6 +206,49 @@ class AngularPowerSpectra(object):
         self.C_ell_h = C_ell_sum
         self.shot_noise = 1./n_h_sr
 
+    ###### halo-matter cross (linear bias) ######
+    def calc_C_ell_h_Sigma(self, zh_min, zh_max, lambda_min=None, lambda_max=None):
+        """halo-Sigma cross angular power spectrum at LINEAR BIAS: P_hm = b * P_mm.
+        Consistent with calc_C_ell_h (b^2 P_mm) and calc_C_ell_Sigma (rho_mean^2 * kernel_Sigma^2).
+        Feeds the (C_ell^hSigma)^2 term of the Gaussian DeltaSigma covariance (Wu et al. (2019), eq. 22).
+        The cross correlates only over the (thin) halo redshift slab, so it is
+        automatically suppressed relative to sqrt(C_ell^hh C_ell^SigmaSigma)."""
+        self.lk.calc_kernel_Sigma(0.5*(zh_min+zh_max))
+
+        # halo bias: same source as calc_C_ell_h
+        try: # are we using PrecalculatedCountsBias() ?
+            b = self.sr.lens_bias
+        except:
+            survey_area_sq_deg = 1437.
+            cc = ClusterCounts(cosmo_parameters=self.co, scaling_relation=self.sr)
+            cc.calc_counts(zmin=zh_min, zmax=zh_max, lambda_min=lambda_min, lambda_max=lambda_max, survey_area_sq_deg=survey_area_sq_deg)
+            b = cc.cluster_mean_bias
+
+        nzh = max(int((zh_max-zh_min)/0.1), 1) # at least one redshift slice
+        zh_bins = np.linspace(zh_min, zh_max, nzh+1)
+        zh_min_list = zh_bins[:-1]
+        zh_max_list = zh_bins[1:]
+
+        C_ell_sum = np.zeros(len(self.ell)) # direct summation over chi
+        vol_sum = 0
+        for izh in range(nzh):
+            zh_mid = 0.5*(zh_min_list[izh]+zh_max_list[izh])
+            chi_h = self.chi(z=zh_mid).value
+            dchi_h = self.chi(z=zh_max_list[izh]).value - self.chi(z=zh_min_list[izh]).value
+            vol_sum += dchi_h * chi_h**2
+            # power spectrum (linear); halo-matter cross = b * P_mm
+            lin = LinearTheory(cosmo=self.cosmo_ying, z=zh_mid)
+            pk_lin = lin.power_spectrum
+            k = (self.ell+0.5)/chi_h
+            Pmm_ell = pk_lin(k)
+            kernel = self.lk.kernel_Sigma_z_interp(zh_mid)
+            summand = dchi_h * kernel * b * Pmm_ell
+            C_ell_sum += summand
+        C_ell_sum = C_ell_sum * self.rho_mean / vol_sum
+
+        self.ell_h_Sigma = self.ell
+        self.C_ell_h_Sigma = C_ell_sum
+
     ###### halo-matter ######
     '''
     def calc_C_ell_h_kappa(self, zh_min, zh_max, Mmin, Mmax):

--- a/clens/lensing/cov_DeltaSigma.py
+++ b/clens/lensing/cov_DeltaSigma.py
@@ -65,13 +65,15 @@ class CovDeltaSigma(object):
         ell_list = np.exp(lnell_list)
 
         ## calculating cosmic shear contribution, from 0.1 to zs_max (zs_max can be up to 2), and interpolate
+        ## C_ell_Sigma depends only on zh_mid (not the radial bin) -> compute once, like C_ell_h
         zh_mid = 0.5*(zh_min+zh_max)
-        if self.slicing == False: ## default: LSS from 0 to zs_max
-            self.aps.calc_C_ell_Sigma(zl_min=0.1, zl_max=min(2,self.su.zs_max-0.1), zh=zh_mid)
-        if self.slicing == True: ## slicing: from zh-dz to zh+dz
-            self.aps.calc_C_ell_Sigma(zl_min=zh_mid-self.dz_slicing, zl_max=zh_mid+self.dz_slicing, zh=zh_mid)
-            print('zh_mid', zh_mid)
-            print('slicing z', zh_mid-self.dz_slicing, zh_mid+self.dz_slicing)
+        if ith1 == 0 and ith2 == 0:
+            if self.slicing == False: ## default: LSS from 0 to zs_max
+                self.aps.calc_C_ell_Sigma(zl_min=0.1, zl_max=min(2,self.su.zs_max-0.1), zh=zh_mid)
+            if self.slicing == True: ## slicing: from zh-dz to zh+dz
+                self.aps.calc_C_ell_Sigma(zl_min=zh_mid-self.dz_slicing, zl_max=zh_mid+self.dz_slicing, zh=zh_mid)
+                print('zh_mid', zh_mid)
+                print('slicing z', zh_mid-self.dz_slicing, zh_mid+self.dz_slicing)
 
         C_ell_Sigma_interp = interp1d(self.aps.ell_Sigma, self.aps.C_ell_Sigma)
         
@@ -89,12 +91,11 @@ class CovDeltaSigma(object):
             halo = C_ell_h_interp(ell_list)
             print('cosmic shear only')
 
-        '''
-        ## TODO!
-        ## calculating the contribution from halo profile: C_ell_hk
-        self.aps.calc_C_ell_h_Sigma(zh_min=zh_min, zh_max=zh_max, Mmin=Mmin, Mmax=Mmax)
+        ## halo-Sigma cross power (linear bias), radial-bin independent -> compute once
+        if ith1 == 0 and ith2 == 0:
+            self.aps.calc_C_ell_h_Sigma(zh_min=zh_min, zh_max=zh_max, lambda_min=lambda_min, lambda_max=lambda_max)
         C_ell_h_Sigma_interp = interp1d(self.aps.ell_h_Sigma, self.aps.C_ell_h_Sigma)
-        '''
+
         ## the J2 part of the integration
         geometry = self.bf.j2_bin(ell_list, thmin1, thmax1) * self.bf.j2_bin(ell_list, thmin2, thmax2) * ell_list**2 / (2.*np.pi)
 
@@ -104,13 +105,13 @@ class CovDeltaSigma(object):
         ## contribution from shape noise, (C_ell^h + halo shot) * shape noise
         integrand_shape_noise = halo * self.aps.shape_noise_for_Sigma * geometry
 
-        ## contribution from halo intrinsic profile, C_ell^hk ** 2  # TODO
-        #integrand_halo_intrinsic = C_ell_h_Sigma_interp(ell_list)**2 * geometry
+        ## cross contribution, (C_ell^hSigma)^2  (eq. 22, third term in the bracket)
+        integrand_cross = C_ell_h_Sigma_interp(ell_list)**2 * geometry
 
         ## integration over ell!
         self.cosmic_shear_integration = np.trapz(integrand_cosmic_shear, x=lnell_list)
         self.shape_noise_integration = np.trapz(integrand_shape_noise, x=lnell_list)
-        #self.halo_intrinsic_integration = np.trapz(integrand_halo_intrinsic, x=lnell_list) # TODO
+        self.cross_integration = np.trapz(integrand_cross, x=lnell_list)
 
     def calc_cov(self, rp_min, rp_max, n_rp, zh_min, zh_max, lambda_min=None, lambda_max=None, diag_only=False):
         """ calling self._calc_C_ell_integration, calculating the cov for *multiple bins*
@@ -125,9 +126,11 @@ class CovDeltaSigma(object):
             diag_only (bool): if True, calculating only the diagnal elements, off-diag will be zero
 
         Returns:
-            cov_cosmic_shear, cov_shape_noise, cov_halo_intrinsic
+            rp_mid_list, cov_cosmic_shear, cov_shape_noise
+            (backward compatible 3-tuple; the (C_ell^hSigma)^2 cross term of
+             eq. 22, linear bias, is available as the attribute self.cov_cross,
+             and is already included in self.cov_sum)
             units all in Msun^2/pc^4
-            one can also directly access these as attributes
         """
         zh_mid = 0.5*(zh_min+zh_max)
         chi_h = self.chi(z=zh_mid).value
@@ -148,7 +151,7 @@ class CovDeltaSigma(object):
 
         self.cov_cosmic_shear = np.zeros([nth, nth])
         self.cov_shape_noise = np.zeros([nth, nth])
-        #self.cov_halo_intrinsic = np.zeros([nth, nth])
+        self.cov_cross = np.zeros([nth, nth])
 
         if diag_only==True: ## only calculating the diagonal elements
             for ith1 in range(nth):
@@ -156,7 +159,7 @@ class CovDeltaSigma(object):
                 self._calc_C_ell_integration(thmin1=thmin_list[ith1], thmax1=thmax_list[ith1], thmin2=thmin_list[ith2], thmax2=thmax_list[ith2], zh_min=zh_min, zh_max=zh_max, lambda_min=lambda_min, lambda_max=lambda_max, ith1=ith1, ith2=ith2)
                 self.cov_shape_noise[ith1,ith1] = factor*self.shape_noise_integration
                 self.cov_cosmic_shear[ith1,ith1] = factor*self.cosmic_shear_integration
-                #self.cov_halo_intrinsic[ith1,ith1] = factor*self.halo_intrinsic_integration
+                self.cov_cross[ith1,ith1] = factor*self.cross_integration
 
         if diag_only==False: ## calculating the off-diagonal elements
             for ith1 in range(nth):
@@ -164,24 +167,24 @@ class CovDeltaSigma(object):
                     self._calc_C_ell_integration(thmin1=thmin_list[ith1], thmax1=thmax_list[ith1], thmin2=thmin_list[ith2], thmax2=thmax_list[ith2], zh_min=zh_min, zh_max=zh_max, lambda_min=lambda_min, lambda_max=lambda_max, ith1=ith1, ith2=ith2)
                     self.cov_shape_noise[ith1, ith2] = factor*self.shape_noise_integration
                     self.cov_cosmic_shear[ith1, ith2] = factor*self.cosmic_shear_integration
-                    #self.cov_halo_intrinsic[ith1, ith2] = factor*self.halo_intrinsic_integration
+                    self.cov_cross[ith1, ith2] = factor*self.cross_integration
 
             ## copy the upper right corner to the lower left corner
             for ith1 in range(nth):
                 for ith2 in range(ith1):
                     self.cov_cosmic_shear[ith1, ith2] = self.cov_cosmic_shear[ith2, ith1]
                     self.cov_shape_noise[ith1, ith2] = self.cov_shape_noise[ith2, ith1]
-                    #self.cov_halo_intrinsic[ith1, ith2] = self.cov_halo_intrinsic[ith2, ith1]
+                    self.cov_cross[ith1, ith2] = self.cov_cross[ith2, ith1]
 
         self.cov_cosmic_shear *= (1e-24) # make it (Msun/pc^2)^2
         self.cov_shape_noise *= (1e-24)
-        #self.cov_halo_intrinsic *= (1e-24)
-        self.cov_sum = self.cov_cosmic_shear + self.cov_shape_noise #+ self.cov_halo_intrinsic
+        self.cov_cross *= (1e-24)
+        self.cov_sum = self.cov_cosmic_shear + self.cov_shape_noise + self.cov_cross
 
         self.rp_min_list = thmin_list * chi_h
         self.rp_max_list = thmax_list * chi_h
         self.rp_mid_list = thmid_list * chi_h
-        return self.rp_mid_list, self.cov_cosmic_shear, self.cov_shape_noise #, self.cov_halo_intrinsic
+        return self.rp_mid_list, self.cov_cosmic_shear, self.cov_shape_noise
 
 
 


### PR DESCRIPTION
## Summary

Implements the halo–Sigma cross contribution `(C_ℓ^{hΣ})²` in the Gaussian
ΔΣ covariance ([Wu et al. (2019)](https://arxiv.org/abs/1907.06611) eq. 22, third term in the bracket), which was previously
stubbed out with a `# TODO`. The cross power is computed at **linear bias**
(`P_hm = b · P_mm`).

## Changes

- **`angular_power_spectra.py`** — new `calc_C_ell_h_Sigma()`: the halo–matter
  cross angular power spectrum. The bias `b` is taken from the same source as
  `calc_C_ell_h` (`PrecalculatedCountsBias` if available, otherwise `ClusterCounts`).
- **`cov_DeltaSigma.py`** — compute `integrand_cross = (C_ℓ^{hΣ})² · geometry`,
  integrate it, expose it as the attribute `self.cov_cross`, and add it to
  `self.cov_sum`.
- **Performance** — `C_ℓ^Σ`, `C_ℓ^h`, and `C_ℓ^{hΣ}` depend only on `zh_mid`,
  not on the radial bin, so they are now computed once per `calc_cov` call
  (guarded by `ith1 == ith2 == 0`) instead of once per (bin, bin) pair. This
  cuts the number of heavy power-spectrum evaluations from ~n_rp²/2 to 1.

## Normalization

Derived consistently with the existing auto-spectra so the three terms combine
correctly:

| Spectrum | Code |
|---|---|
| `C^hh`   | `Σ dχ·χ²·b²·P / vol_sum²` |
| `C^ΣΣ`   | `ρ̄² · Σ dχ·kernel²/χ²·P` |
| `C^hΣ`   | `ρ̄ · b/vol_sum · Σ dχ·kernel·P` |

For the cross, the Limber `1/χ²` cancels the `χ²` in the halo radial
selection kernel. The resulting `cov_sum` has the standard Gaussian form
`(C^hh+shot)(C^ΣΣ+shape) + (C^hΣ)²`, with unit coefficient on the cross term.

## Testing

Ran the `demo_cov()` setup end-to-end:

- `cov_sum` is finite everywhere.
- The cross term is **~0.1–1.3% of the cosmic-shear term**, matching the
  physical expectation that a thin halo redshift slab suppresses the cross
  relative to `sqrt(C^hh · C^ΣΣ)`.

## ⚠️ Behavior change to note

`self.cov_sum` now includes `cov_cross`, so results that read `cov_sum` will
shift slightly (a fraction of a percent in the tested config). The return
tuple of `calc_cov` is unchanged (`rp_mid_list, cov_cosmic_shear,
cov_shape_noise`); `cov_cross` is accessible as an attribute. Happy to gate
this behind an `include_cross=True` flag if you'd prefer the default to stay
byte-for-byte identical.
